### PR TITLE
Add progressive nesting diagram slides

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,9 +2,10 @@
   "name": "OrchLab Workshop Slides",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
   "features": {
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/python:1": {}
   },
-  "postCreateCommand": "npm install && sudo npm install -g @anthropic-ai/claude-code",
+  "postCreateCommand": "npm install && sudo npm install -g @anthropic-ai/claude-code && sudo apt-get update && sudo apt-get install -y libreoffice-impress poppler-utils && pip install 'markitdown[pptx]'",
   "customizations": {
     "vscode": {
       "settings": {

--- a/src/data/part1.js
+++ b/src/data/part1.js
@@ -261,6 +261,27 @@ module.exports = [
     }
   },
 
+  // SLIDE 8b — From Action to Task (nesting diagram, 2 visible)
+  {
+    type: "custom",
+    render(pres, ctx) {
+      const { C, FONT } = ctx.branding;
+      const { darkSlide, nestingDiagram } = ctx.helpers;
+
+      const s = darkSlide(pres, null, FT);
+      s.addText("From Action to Task", {
+        x: 0.8, y: 0.2, w: 8, h: 0.5,
+        fontSize: 28, fontFace: FONT.head, color: C.accent, bold: true, margin: 0
+      });
+      s.addText("Combining atomic actions into purposeful tasks", {
+        x: 0.8, y: 0.7, w: 6, h: 0.3,
+        fontSize: 13, fontFace: FONT.body, color: C.muted, italic: true, margin: 0
+      });
+      nestingDiagram(s, pres, 2);
+      s.addNotes("Pause after the coding challenges to frame what participants just did. Each challenge involved multiple atomic actions — completions, edits, test runs — combined into a purposeful task. The dashed outer rings hint that there are higher levels of orchestration to come. We'll fill those in as the workshop progresses.");
+    },
+  },
+
   // SLIDE 9 — Activity: Design Your Own Claude Code
   {
     type: "custom",

--- a/src/data/part2.js
+++ b/src/data/part2.js
@@ -817,6 +817,27 @@ module.exports = [
     }
   },
 
+  // SLIDE 31b — From Task to Flow (nesting diagram, 3 visible)
+  {
+    type: "custom",
+    render(pres, ctx) {
+      const { C, FONT } = ctx.branding;
+      const { darkSlide, nestingDiagram } = ctx.helpers;
+
+      const s = darkSlide(pres, null, FT);
+      s.addText("From Task to Flow", {
+        x: 0.8, y: 0.2, w: 8, h: 0.5,
+        fontSize: 28, fontFace: FONT.head, color: C.accent, bold: true, margin: 0
+      });
+      s.addText("Chaining tasks into an autonomous Plan \u2192 Do \u2192 Review flow", {
+        x: 0.8, y: 0.7, w: 7, h: 0.3,
+        fontSize: 13, fontFace: FONT.body, color: C.muted, italic: true, margin: 0
+      });
+      nestingDiagram(s, pres, 3);
+      s.addNotes("After the Socratic spec activity, participants have experienced the full Plan-Do-Review flow: they interviewed for requirements (plan), generated output (do), and refined it (review). This is the third layer of the nesting model. The dashed outer ring hints at the final level — loops — which we'll cover in Part 3 when we discuss self-correcting autonomous systems.");
+    },
+  },
+
   // SLIDE 32 — Part 2 Takeaways
   {
     type: "custom",

--- a/src/data/part3.js
+++ b/src/data/part3.js
@@ -701,6 +701,125 @@ module.exports = [
     },
   },
 
+  // SLIDE 46b — From Actions to Loops (nested concentric)
+  {
+    type: "custom",
+    render(pres, ctx) {
+      const { C, FONT } = ctx.branding;
+      const { darkSlide, nestingDiagram } = ctx.helpers;
+
+      const s = darkSlide(pres, null, FT);
+      s.addText("From Actions to Loops", {
+        x: 0.8, y: 0.2, w: 8, h: 0.5,
+        fontSize: 28, fontFace: FONT.head, color: C.accent, bold: true, margin: 0
+      });
+      s.addText("Building up the units of AI-assisted development", {
+        x: 0.8, y: 0.7, w: 6, h: 0.3,
+        fontSize: 13, fontFace: FONT.body, color: C.muted, italic: true, margin: 0
+      });
+      nestingDiagram(s, pres, 4);
+      s.addNotes("Walk through from the inside out. Actions are the atomic unit — what we covered in Part 1. Tasks combine multiple actions towards a goal — Part 2 territory. Flows chain planning, execution, and review into an autonomous pipeline — this is what we've been building in Part 3. Loops wrap flows in self-correcting feedback: the output of a review feeds back into the next plan until the outcome is met. Each layer multiplies the previous one.");
+    },
+  },
+
+  // SLIDE 46c — Scaling the Loop (macro level)
+  {
+    type: "custom",
+    render(pres, ctx) {
+      const { C, FONT, makeShadow } = ctx.branding;
+      const { darkSlide, addCard } = ctx.helpers;
+
+      const s = darkSlide(pres, null, FT);
+      s.addText("Scaling the Loop", {
+        x: 0.8, y: 0.2, w: 8, h: 0.5,
+        fontSize: 28, fontFace: FONT.head, color: C.accent, bold: true, margin: 0
+      });
+      s.addText("From individual loops to organisational feedback cycles", {
+        x: 0.8, y: 0.7, w: 7, h: 0.3,
+        fontSize: 13, fontFace: FONT.body, color: C.muted, italic: true, margin: 0
+      });
+
+      // Three tiers stacked vertically, each wider than the last
+      // Tier 1: Loop (narrow, top)
+      addCard(s, 3.0, 1.2, 4.0, 0.8, C.accent, pres);
+      s.addText("LOOP", {
+        x: 3.2, y: 1.25, w: 2.0, h: 0.3,
+        fontSize: 14, fontFace: FONT.head, color: C.accent, bold: true, margin: 0
+      });
+      s.addText("A single Plan \u2192 Do \u2192 Review cycle on one task", {
+        x: 3.2, y: 1.55, w: 3.6, h: 0.35,
+        fontSize: 11, fontFace: FONT.body, color: C.offWhite, margin: 0
+      });
+
+      // Tier 2: Macro Flow (medium, middle) — taller to fit steps
+      addCard(s, 2.0, 2.3, 6.0, 1.5, C.warnAmber, pres);
+      s.addText("MACRO FLOW", {
+        x: 2.2, y: 2.35, w: 3.0, h: 0.3,
+        fontSize: 14, fontFace: FONT.head, color: C.warnAmber, bold: true, margin: 0
+      });
+      s.addText("Chaining loops into a sprint-level pipeline", {
+        x: 2.2, y: 2.65, w: 5.6, h: 0.3,
+        fontSize: 11, fontFace: FONT.body, color: C.offWhite, margin: 0
+      });
+      // Plan → Do → Review step boxes
+      const steps = ["Plan", "Do", "Review"];
+      const stepW = 1.4;
+      const stepGap = 0.4;
+      const totalStepsW = 3 * stepW + 2 * stepGap;
+      const stepStartX = 2.0 + (6.0 - totalStepsW) / 2;
+      steps.forEach((step, i) => {
+        const sx = stepStartX + i * (stepW + stepGap);
+        s.addShape(pres.shapes.ROUNDED_RECTANGLE, {
+          x: sx, y: 3.05, w: stepW, h: 0.55,
+          fill: { color: C.lightBg }, rectRadius: 0.08
+        });
+        s.addText(step, {
+          x: sx, y: 3.05, w: stepW, h: 0.55,
+          fontSize: 13, fontFace: FONT.head, color: C.warnAmber, bold: true,
+          align: "center", valign: "middle", margin: 0
+        });
+        if (i < 2) {
+          s.addText("\u2192", {
+            x: sx + stepW, y: 3.05, w: stepGap, h: 0.55,
+            fontSize: 18, fontFace: FONT.body, color: C.muted,
+            align: "center", valign: "middle", margin: 0
+          });
+        }
+      });
+
+      // Tier 3: Macro Loop (wide, bottom)
+      addCard(s, 1.0, 4.1, 8.0, 0.8, C.highlightYellow, pres);
+      s.addText("MACRO LOOP", {
+        x: 1.2, y: 4.15, w: 3.0, h: 0.3,
+        fontSize: 14, fontFace: FONT.head, color: C.highlightYellow, bold: true, margin: 0
+      });
+      s.addText("Continuous feedback: outcomes inform the next macro flow, adapting strategy over time", {
+        x: 1.2, y: 4.45, w: 7.6, h: 0.35,
+        fontSize: 11, fontFace: FONT.body, color: C.offWhite, margin: 0
+      });
+
+      // Feedback arrows (vertical dashed lines connecting tiers)
+      s.addShape(pres.shapes.LINE, {
+        x: 9.2, y: 1.6, w: 0, h: 3.3,
+        line: { color: C.muted, width: 1.5, dashType: "dash" }
+      });
+      s.addText("\u2191 feedback", {
+        x: 9.0, y: 2.9, w: 0.9, h: 0.4,
+        fontSize: 9, fontFace: FONT.body, color: C.muted, margin: 0
+      });
+      s.addShape(pres.shapes.LINE, {
+        x: 0.7, y: 1.6, w: 0, h: 3.3,
+        line: { color: C.muted, width: 1.5, dashType: "dash" }
+      });
+      s.addText("\u2193 scale", {
+        x: 0.15, y: 2.9, w: 0.6, h: 0.4,
+        fontSize: 9, fontFace: FONT.body, color: C.muted, margin: 0
+      });
+
+      s.addNotes("This slide zooms out from the individual loop to the macro level. A Loop is a single Plan-Do-Review cycle on one task — what participants experienced in the activities. A Macro Flow chains multiple loops together: plan the sprint, execute tasks in parallel loops, review outcomes as a batch. A Macro Loop is the organisational feedback cycle: the outcomes of one macro flow inform the strategy for the next. This is how AI-assisted development scales from individual productivity to team and organisational transformation. The feedback arrow on the right shows learning flowing back up; the scale arrow on the left shows strategy flowing down.");
+    },
+  },
+
   // SLIDE 47 — Tools & Ecosystem
   {
     type: "custom",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -58,4 +58,61 @@ function iconCircle(slide, iconKey, x, y, size, bgColor, icons, pres) {
   });
 }
 
-module.exports = { addFooter, addSlideNumber, darkSlide, lightSlide, addCard, addLightCard, iconCircle };
+/**
+ * Renders the nested Action → Task → Flow → Loop concentric diagram.
+ * @param {object} s - slide object
+ * @param {object} pres - presentation object
+ * @param {number} visibleCount - how many layers to show as solid (1=Action, 2=+Task, 3=+Flow, 4=+Loop)
+ */
+function nestingDiagram(s, pres, visibleCount) {
+  const cx = 3.2, cy = 3.15;
+  const allLayers = [
+    { label: "Loop",   color: C.warnAmber,       w: 5.4, h: 3.4, desc: "Self-correcting cycles that feed back to meet an outcome" },
+    { label: "Flow",   color: C.highlightYellow,  w: 4.2, h: 2.5, desc: "Plan \u2192 Do \u2192 Review combined into an autonomous flow" },
+    { label: "Task",   color: C.accentDim,        w: 3.0, h: 1.6, desc: "Bulk rename, dependency upgrades, implement interface" },
+    { label: "Action", color: C.accent,            w: 1.8, h: 0.7, desc: "Code completion, run test, answer question" },
+  ];
+
+  // visibleCount counts from inner: 1=Action, 2=Action+Task, etc.
+  // allLayers is ordered outer→inner, so visible threshold is (4 - visibleCount)
+  const dimThreshold = allLayers.length - visibleCount;
+
+  allLayers.forEach((l, i) => {
+    const x = cx - l.w / 2;
+    const y = cy - l.h / 2;
+    const isDim = i < dimThreshold;
+    s.addShape(pres.shapes.ROUNDED_RECTANGLE, {
+      x, y, w: l.w, h: l.h,
+      fill: { type: "none" },
+      line: { color: isDim ? C.lightBg : l.color, width: isDim ? 1 : 2.5, dashType: isDim ? "dash" : "solid" },
+      rectRadius: 0.15
+    });
+    if (!isDim) {
+      s.addText(l.label.toUpperCase(), {
+        x: x + 0.15, y: y + l.h - 0.35, w: 1.2, h: 0.3,
+        fontSize: 11, fontFace: FONT.head, color: l.color, bold: true, margin: 0
+      });
+    }
+  });
+
+  // Right-side legend — only for visible layers, reads inside-out
+  const legendX = 6.2, legendStartY = 1.6;
+  const visibleLayers = allLayers.slice(dimThreshold).reverse();
+  visibleLayers.forEach((l, i) => {
+    const y = legendStartY + i * 0.7;
+    s.addShape(pres.shapes.OVAL, {
+      x: legendX, y: y + 0.05, w: 0.18, h: 0.18,
+      fill: { color: l.color }
+    });
+    s.addText(l.label, {
+      x: legendX + 0.3, y: y - 0.02, w: 3.2, h: 0.25,
+      fontSize: 11, fontFace: FONT.head, color: l.color, bold: true, margin: 0
+    });
+    s.addText(l.desc, {
+      x: legendX + 0.3, y: y + 0.22, w: 3.2, h: 0.4,
+      fontSize: 9.5, fontFace: FONT.body, color: C.muted, margin: 0
+    });
+  });
+}
+
+module.exports = { addFooter, addSlideNumber, darkSlide, lightSlide, addCard, addLightCard, iconCircle, nestingDiagram };


### PR DESCRIPTION
## Summary
- Adds a reusable `nestingDiagram()` helper to `src/helpers.js` that renders the Action → Task → Flow → Loop concentric model with configurable visibility (unlit layers render as dashed ghost outlines)
- Inserts three progressive-reveal slides throughout the deck:
  - **After Slide 8** (Part 1): "From Action to Task" — 2 layers solid, 2 dashed
  - **After Slide 31** (Part 2): "From Task to Flow" — 3 layers solid, 1 dashed
  - **After Slide 46** (Part 3): "From Actions to Loops" — all 4 layers solid
- Adds a **"Scaling the Loop"** slide after the full nesting diagram showing the macro level: Loop → Macro Flow (with Plan/Do/Review steps) → Macro Loop
- Updates `.devcontainer/devcontainer.json` with Python, LibreOffice Impress, poppler-utils, and markitdown for visual QA workflows

## Test plan
- [ ] Run `npm run build` — deck generates without errors
- [ ] Convert to images and verify slides 9, 33, 49, 50 render correctly
- [ ] Rebuild devcontainer and confirm QA tools are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)