### PR TITLE
Rename 'Agent D Deploys' to 'Pipeline Deploys' in Part 3 pipeline slide

### DIFF
--- a/src/data/part3.js
+++ b/src/data/part3.js
@@ -504,7 +504,7 @@ module.exports = [
         { label: "Agent B\nCodes", color: C.accentDim },
         { label: "Agent C\nTests", color: C.midBg },
         { label: "Human\nApproves", color: C.warnAmber },
-        { label: "Agent D\nDeploys", color: C.darkBg },
+        { label: "Pipeline\nDeploys", color: C.darkBg },
       ];
       pipeline.forEach((p, i) => {
         const x = 0.3 + i * 1.95;


### PR DESCRIPTION
## Summary

- Relabels the final stage of the Part 3 pipeline diagram from "Agent D Deploys" to "Pipeline Deploys"

## Why

The label "Agent D" implies a named agent, but the deploy step is better described as a generic pipeline action — keeping it consistent with how the other stages are conceptually framed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)