### PR TITLE
Add presenter reminder icons to title slide

### DIFF
--- a/src/data/intro.js
+++ b/src/data/intro.js
@@ -31,6 +31,11 @@ module.exports = [
         fontSize: 12, fontFace: FONT.body, color: C.muted, align: "center", margin: 0,
         hyperlink: { url: "https://orchlab.ai/workshop-deck" },
       });
+      // Presenter reminders (top-right, icons only)
+      ["plug", "wifi", "bellSlash"].forEach((icon, i) => {
+        s.addImage({ data: icons[icon], x: 9.08 - i * 0.4, y: 0.12, w: 0.28, h: 0.28 });
+      });
+
       s.addNotes("Welcome everyone to OrchLab. This workshop takes you on a journey from basic AI copy-paste coding all the way to orchestrating teams of AI agents. We'll move through three parts: first getting AI into your workflow, then learning to communicate effectively with AI through specs, and finally building autonomous agent systems. Each section builds on the last, so by the end you'll have a clear roadmap for where you are today and where you can go.");
     },
   },

--- a/src/icons.js
+++ b/src/icons.js
@@ -11,7 +11,7 @@ const {
   FaProjectDiagram, FaChessKing, FaBook, FaHandshake, FaPlay,
   FaStepForward, FaStepBackward, FaExpand, FaCompress, FaDraftingCompass, FaArrowUp,
   FaLock, FaTerminal, FaCodeBranch, FaKey, FaUserShield, FaDocker, FaServer,
-  FaLinkedin, FaDiscord
+  FaLinkedin, FaDiscord, FaPlug, FaWifi, FaBellSlash
 } = require("react-icons/fa");
 
 const {
@@ -84,6 +84,9 @@ const iconList = [
   ["linkedinWhite", FaLinkedin, "#FFFFFF"],
   ["discord", FaDiscord, "#8CC26C"],
   ["discordWhite", FaDiscord, "#FFFFFF"],
+  ["plug", FaPlug, "#E8B84A"],
+  ["wifi", FaWifi, "#E8B84A"],
+  ["bellSlash", FaBellSlash, "#E8B84A"],
 ];
 
 async function iconToBase64Png(IconComponent, color, size = 256) {


### PR DESCRIPTION
## Summary

- Adds three small amber icons (plug, wifi, bell-slash) to the top-right corner of the title slide
- Icons serve as subtle pre-workshop reminders for the presenter: plug in power, share WiFi, silence notifications
- No text labels — icons only, keeping the slide clean

## Test plan

- [x] Build with `node build.js` and visually confirm icons appear in the top-right corner of slide 1
- [ ] Confirm no other slides are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)