### PR TITLE
Add Welcome & Introductions slide and standardise directional arrows

### DIFF
--- a/src/data/appendix.js
+++ b/src/data/appendix.js
@@ -70,10 +70,7 @@ module.exports = [
           fontSize: 10, fontFace: FONT.body, color: C.offWhite, align: "center", margin: 0
         });
         if (i < steps.length - 1) {
-          s.addText("\u25B6", {
-            x: x + 1.9, y: y + 0.75, w: 0.3, h: 0.4,
-            fontSize: 16, fontFace: FONT.body, color: C.accent, align: "center", valign: "middle", margin: 0
-          });
+          s.addImage({ data: icons.arrow, x: x + 1.875, y: y + 0.825, w: 0.35, h: 0.35 });
         }
       });
 
@@ -396,10 +393,7 @@ module.exports = [
       });
 
       // Arrow from Ollama to tools
-      s.addText("\u25B6", {
-        x: 4.15, y: 2.75, w: 0.4, h: 0.4,
-        fontSize: 20, fontFace: FONT.body, color: C.accent, align: "center", valign: "middle", margin: 0
-      });
+      s.addImage({ data: icons.arrow, x: 4.175, y: 2.775, w: 0.35, h: 0.35 });
 
       // Tools grid — right side (3 rows x 2 cols, compact)
       const tools = [

--- a/src/data/intro.js
+++ b/src/data/intro.js
@@ -39,7 +39,149 @@ module.exports = [
       s.addNotes("Welcome everyone to OrchLab. This workshop takes you on a journey from basic AI copy-paste coding all the way to orchestrating teams of AI agents. We'll move through three parts: first getting AI into your workflow, then learning to communicate effectively with AI through specs, and finally building autonomous agent systems. Each section builds on the last, so by the end you'll have a clear roadmap for where you are today and where you can go.");
     },
   },
-  // SLIDE 2 — CONTEXT SETTING: Software Development Is a Spectrum
+  // SLIDE 2 — YOUR JOURNEY TODAY (Advance Organizer / Roadmap)
+  {
+    type: "custom",
+    render(pres, ctx) {
+      const { C, FONT, makeShadow } = ctx.branding;
+      const { darkSlide, addCard, iconCircle } = ctx.helpers;
+      const { icons } = ctx;
+
+      const s = darkSlide(pres);
+
+      // Title
+      s.addText("Your Journey Today", {
+        x: 0.8, y: 0.35, w: 8.4, h: 0.6,
+        fontSize: 28, fontFace: FONT.head, color: C.white, bold: true, margin: 0
+      });
+      s.addText("Three steps from where you are now to where you could be.", {
+        x: 0.8, y: 0.95, w: 8.4, h: 0.4,
+        fontSize: 13, fontFace: FONT.body, color: C.muted, margin: 0
+      });
+
+      // Three part cards as a horizontal journey
+      const parts = [
+        {
+          num: "1", icon: "code", color: C.accent,
+          title: "AI Coding",
+          desc: "Move from copy-paste to tools that see your whole codebase."
+        },
+        {
+          num: "2", icon: "clipboard", color: C.accentDim,
+          title: "Prompt Engineering",
+          desc: "Learn to write specs that give AI the context it needs to succeed."
+        },
+        {
+          num: "3", icon: "sitemap", color: C.warnAmber,
+          title: "Orchestration",
+          desc: "Coordinate multiple agents into autonomous workflows."
+        },
+      ];
+
+      const cardW = 2.6;
+      const cardH = 2.4;
+      const cardY = 1.7;
+      const gap = 0.3;
+      const startX = (10 - (parts.length * cardW + (parts.length - 1) * gap)) / 2;
+
+      parts.forEach((p, i) => {
+        const x = startX + i * (cardW + gap);
+
+        // Card background
+        addCard(s, x, cardY, cardW, cardH, p.color, pres);
+
+        // Part number
+        s.addText("PART " + p.num, {
+          x: x + 0.2, y: cardY + 0.15, w: cardW - 0.4, h: 0.3,
+          fontSize: 10, fontFace: FONT.head, color: p.color, bold: true, charSpacing: 3, margin: 0
+        });
+
+        // Icon
+        iconCircle(s, p.icon, x + (cardW - 0.55) / 2, cardY + 0.55, 0.55, p.color, icons, pres);
+
+        // Title
+        s.addText(p.title, {
+          x: x + 0.15, y: cardY + 1.25, w: cardW - 0.3, h: 0.35,
+          fontSize: 15, fontFace: FONT.head, color: C.white, bold: true, align: "center", margin: 0
+        });
+
+        // Description
+        s.addText(p.desc, {
+          x: x + 0.15, y: cardY + 1.6, w: cardW - 0.3, h: 0.7,
+          fontSize: 11, fontFace: FONT.body, color: C.offWhite, align: "center", margin: 0
+        });
+
+        // Arrow between cards
+        if (i < parts.length - 1) {
+          const arrowX = x + cardW + (gap - 0.3) / 2;
+          s.addImage({ data: icons.arrow, x: arrowX, y: cardY + cardH / 2 - 0.15, w: 0.3, h: 0.3 });
+        }
+      });
+
+      // Bottom anchor — connects to what they already know
+      s.addShape(pres.shapes.RECTANGLE, {
+        x: 0.8, y: 4.5, w: 8.4, h: 0.7,
+        fill: { color: C.cardBg }, shadow: makeShadow(), rectRadius: 0.08
+      });
+      s.addShape(pres.shapes.RECTANGLE, {
+        x: 0.8, y: 4.5, w: 0.06, h: 0.7, fill: { color: C.accent }
+      });
+      s.addText("Each part builds on the last. By the end, you\u2019ll have hands-on experience at every level.", {
+        x: 1.1, y: 4.5, w: 7.8, h: 0.7,
+        fontSize: 13, fontFace: FONT.body, color: C.offWhite, valign: "middle", margin: 0
+      });
+
+      s.addNotes("Before we jump in, here\u2019s the roadmap. We\u2019re going on a journey through three stages. Part 1 is about getting AI tools integrated into your actual workflow \u2014 not just copy-pasting from a chat window. Part 2 is about learning to communicate with AI effectively, using specs and structured prompts instead of ad-hoc instructions. And Part 3 is where it gets really interesting \u2014 orchestrating multiple AI agents into autonomous workflows that can handle complex tasks. Each section builds on the one before it. So if you\u2019re brand new to AI coding, Part 1 will get you up to speed. If you\u2019re already using Copilot or Claude, Parts 2 and 3 will take you to the next level. Let\u2019s get started.");
+    }
+  },
+  // SLIDE 3 — WELCOME & INTRODUCTIONS
+  {
+    type: "custom",
+    render(pres, ctx) {
+      const { C, FONT } = ctx.branding;
+      const { lightSlide, addLightCard } = ctx.helpers;
+
+      const s = lightSlide(pres);
+      s.addShape(pres.shapes.RECTANGLE, {
+        x: 0, y: 0, w: 10, h: 0.8, fill: { color: C.midBg }
+      });
+      s.addText("ACTIVITY", {
+        x: 0.8, y: 0.15, w: 3, h: 0.5,
+        fontSize: 24, fontFace: FONT.head, color: C.accent, bold: true, margin: 0
+      });
+      s.addText("Welcome & Introductions", {
+        x: 0.8, y: 1.0, w: 7, h: 0.5,
+        fontSize: 22, fontFace: FONT.head, color: C.darkText, bold: true, margin: 0
+      });
+      s.addText("~1 min each \u2014 we\u2019ll go around the room", {
+        x: 0.8, y: 1.55, w: 7.5, h: 0.4,
+        fontSize: 13, fontFace: FONT.body, color: "444444", italic: true, margin: 0
+      });
+
+      const prompts = [
+        { num: "01", title: "Your name" },
+        { num: "02", title: "Who you work for" },
+        { num: "03", title: "What AI tools are you using today?" },
+        { num: "04", title: "What are you hoping to get out of today?" },
+      ];
+      // 4 cards: start=2.05, spacing=0.82, h=0.65 → last bottom = 2.05+3*0.82+0.65 = 5.16 (fits in 5.625)
+      prompts.forEach((p, i) => {
+        const y = 2.05 + i * 0.82;
+        addLightCard(s, 0.8, y, 6.5, 0.65, C.accentDim, pres);
+        s.addText(p.num, {
+          x: 1.0, y: y, w: 0.55, h: 0.65,
+          fontSize: 20, fontFace: FONT.head, color: C.accentDim, bold: true, valign: "middle", margin: 0
+        });
+        s.addText(p.title, {
+          x: 1.7, y: y, w: 5.2, h: 0.65,
+          fontSize: 14, fontFace: FONT.head, color: C.darkText, bold: true, valign: "middle", margin: 0
+        });
+      });
+
+      s.addNotes("Go first yourself \u2014 it models the format and sets the pace. Keep your own intro to 30 seconds. Listen for experience signals on question 03: who's using AI daily vs. who's brand new. That tells you how much to slow down in Part 1. Question 04 often surfaces specific goals you can call back to later in the workshop.");
+    }
+  },
+  // SLIDE 4 — CONTEXT SETTING: Software Development Is a Spectrum
   {
     type: "custom",
     render(pres, ctx) {
@@ -160,7 +302,7 @@ module.exports = [
       s.addNotes("Before we dive in, let's set context. Not all software is the same. A quick shell script has different needs than a platform serving millions of users. And the intent behind what you're building shifts over time — you might start in discovery mode, push to market, then spend years maintaining and integrating. AI accelerates all of this. You'll write more throwaway scripts, spin up more prototypes, ship faster. But this workshop focuses specifically on the team-scale, long-lived end of the spectrum — where the stakes are highest and the practices matter most.");
     },
   },
-  // SLIDE 3 — Environment Check (setup verification)
+  // SLIDE 5 — Environment Check (setup verification)
   {
     type: "custom",
     render(pres, ctx) {
@@ -225,104 +367,6 @@ module.exports = [
         fontSize: 12, fontFace: FONT.body, color: C.darkText, align: "center", margin: 0
       });
       s.addNotes("While we're getting settled — can everyone scan this QR code and clone this repo? [show QR code] Just clone it and run it. No coding required. Docker will start, Claude will run inside the container, and Playwright will take a screenshot of a simple web page. [pause] This verifies three things we'll rely on all day: your Docker setup, your agent CLI, and headless browser automation. If anything doesn't work, flag me now — much easier to fix before we're mid-exercise.");
-    }
-  },
-  // SLIDE — YOUR JOURNEY TODAY (Advance Organizer / Roadmap)
-  {
-    type: "custom",
-    render(pres, ctx) {
-      const { C, FONT, makeShadow } = ctx.branding;
-      const { darkSlide, addCard, iconCircle } = ctx.helpers;
-      const { icons } = ctx;
-
-      const s = darkSlide(pres);
-
-      // Title
-      s.addText("Your Journey Today", {
-        x: 0.8, y: 0.35, w: 8.4, h: 0.6,
-        fontSize: 28, fontFace: FONT.head, color: C.white, bold: true, margin: 0
-      });
-      s.addText("Three steps from where you are now to where you could be.", {
-        x: 0.8, y: 0.95, w: 8.4, h: 0.4,
-        fontSize: 13, fontFace: FONT.body, color: C.muted, margin: 0
-      });
-
-      // Three part cards as a horizontal journey
-      const parts = [
-        {
-          num: "1", icon: "code", color: C.accent,
-          title: "AI Coding",
-          desc: "Move from copy-paste to tools that see your whole codebase."
-        },
-        {
-          num: "2", icon: "clipboard", color: C.accentDim,
-          title: "Prompt Engineering",
-          desc: "Learn to write specs that give AI the context it needs to succeed."
-        },
-        {
-          num: "3", icon: "sitemap", color: C.warnAmber,
-          title: "Orchestration",
-          desc: "Coordinate multiple agents into autonomous workflows."
-        },
-      ];
-
-      const cardW = 2.6;
-      const cardH = 2.4;
-      const cardY = 1.7;
-      const gap = 0.3;
-      const startX = (10 - (parts.length * cardW + (parts.length - 1) * gap)) / 2;
-
-      parts.forEach((p, i) => {
-        const x = startX + i * (cardW + gap);
-
-        // Card background
-        addCard(s, x, cardY, cardW, cardH, p.color, pres);
-
-        // Part number
-        s.addText("PART " + p.num, {
-          x: x + 0.2, y: cardY + 0.15, w: cardW - 0.4, h: 0.3,
-          fontSize: 10, fontFace: FONT.head, color: p.color, bold: true, charSpacing: 3, margin: 0
-        });
-
-        // Icon
-        iconCircle(s, p.icon, x + (cardW - 0.55) / 2, cardY + 0.55, 0.55, p.color, icons, pres);
-
-        // Title
-        s.addText(p.title, {
-          x: x + 0.15, y: cardY + 1.25, w: cardW - 0.3, h: 0.35,
-          fontSize: 15, fontFace: FONT.head, color: C.white, bold: true, align: "center", margin: 0
-        });
-
-        // Description
-        s.addText(p.desc, {
-          x: x + 0.15, y: cardY + 1.6, w: cardW - 0.3, h: 0.7,
-          fontSize: 11, fontFace: FONT.body, color: C.offWhite, align: "center", margin: 0
-        });
-
-        // Arrow between cards
-        if (i < parts.length - 1) {
-          const arrowX = x + cardW + (gap - 0.3) / 2;
-          s.addText("\u25B6", {
-            x: arrowX, y: cardY + cardH / 2 - 0.2, w: 0.3, h: 0.4,
-            fontSize: 14, fontFace: FONT.body, color: C.muted, align: "center", valign: "middle", margin: 0
-          });
-        }
-      });
-
-      // Bottom anchor — connects to what they already know
-      s.addShape(pres.shapes.RECTANGLE, {
-        x: 0.8, y: 4.5, w: 8.4, h: 0.7,
-        fill: { color: C.cardBg }, shadow: makeShadow(), rectRadius: 0.08
-      });
-      s.addShape(pres.shapes.RECTANGLE, {
-        x: 0.8, y: 4.5, w: 0.06, h: 0.7, fill: { color: C.accent }
-      });
-      s.addText("Each part builds on the last. By the end, you\u2019ll have hands-on experience at every level.", {
-        x: 1.1, y: 4.5, w: 7.8, h: 0.7,
-        fontSize: 13, fontFace: FONT.body, color: C.offWhite, valign: "middle", margin: 0
-      });
-
-      s.addNotes("Before we jump in, here\u2019s the roadmap. We\u2019re going on a journey through three stages. Part 1 is about getting AI tools integrated into your actual workflow \u2014 not just copy-pasting from a chat window. Part 2 is about learning to communicate with AI effectively, using specs and structured prompts instead of ad-hoc instructions. And Part 3 is where it gets really interesting \u2014 orchestrating multiple AI agents into autonomous workflows that can handle complex tasks. Each section builds on the one before it. So if you\u2019re brand new to AI coding, Part 1 will get you up to speed. If you\u2019re already using Copilot or Claude, Parts 2 and 3 will take you to the next level. Let\u2019s get started.");
     }
   },
 ];

--- a/src/data/part1.js
+++ b/src/data/part1.js
@@ -257,7 +257,7 @@ module.exports = [
         { text: "Together you trial and refine ideas", options: { bullet: true, fontSize: 13, fontFace: FONT.body, color: C.offWhite } },
       ];
       s.addText(pairItems, { x: 5.5, y: 2.3, w: 3.4, h: 1.8, margin: 0 });
-      s.addImage({ data: icons.arrow, x: 4.55, y: 2.7, w: 0.5, h: 0.5 });
+      s.addImage({ data: icons.arrow, x: 4.825, y: 2.825, w: 0.35, h: 0.35 });
       s.addNotes("Think about the last time you phoned a friend for coding advice. They say 'oh yeah, just refactor the service layer' — and it sounds great in theory. But they can't see your screen. They don't know your dependencies, your test setup, your deployment pipeline. Now compare that with pair programming — your partner sees your screen, knows the codebase, and you collaborate in real time. [pause] That's exactly the difference between browser-based AI chat and contextually integrated AI tools. We want to move from the phone call on the left to the pairing session on the right.");
     }
   },
@@ -534,10 +534,7 @@ module.exports = [
           fontSize: 11, fontFace: FONT.body, color: C.offWhite, margin: 0
         });
         // Arrow separator
-        s.addText("→", {
-          x: 4.55, y: y + 0.05, w: 0.4, h: 0.7,
-          fontSize: 20, fontFace: FONT.head, color: C.muted, valign: "middle", align: "center", margin: 0
-        });
+        s.addImage({ data: icons.arrow, x: 4.575, y: y + 0.225, w: 0.35, h: 0.35 });
         // AI side
         s.addText(r.ai, {
           x: 5.1, y: y + 0.05, w: 3.8, h: 0.3,

--- a/src/data/part2.js
+++ b/src/data/part2.js
@@ -658,7 +658,7 @@ module.exports = [
       });
       flowSteps.forEach((fs, i) => {
         if (i < flowSteps.length - 1) {
-          s.addImage({ data: icons.arrowWhite, x: fs.x + 1.9, y: 2.15, w: 0.5, h: 0.5 });
+          s.addImage({ data: icons.arrow, x: fs.x + 1.825, y: 2.275, w: 0.35, h: 0.35 });
         }
       });
       s.addText("Use an \"Architect Agent\" to interview you (Socratic method), generate the brief, combine it with standards to create tasks, then generate code from tasks.", {

--- a/src/data/part3.js
+++ b/src/data/part3.js
@@ -520,7 +520,7 @@ module.exports = [
           fontSize: 12, fontFace: FONT.head, color: C.offWhite, bold: true, align: "center", valign: "middle", margin: 0
         });
         if (i < pipeline.length - 1) {
-          s.addImage({ data: icons.arrowWhite, x: x + 1.72, y: 1.95, w: 0.2, h: 0.2 });
+          s.addImage({ data: icons.arrow, x: x + 1.675, y: 2.05, w: 0.3, h: 0.3 });
         }
       });
       s.addText("You commit a spec. The swarm wakes up.", {
@@ -573,7 +573,7 @@ module.exports = [
           fontSize: 14, fontFace: FONT.head, color: C.offWhite, bold: true, align: "center", valign: "middle", margin: 0
         });
         if (i < linearSteps.length - 1) {
-          s.addImage({ data: icons.arrowWhite, x: x + 1.85, y: 2.3, w: 0.2, h: 0.2 });
+          s.addImage({ data: icons.arrow, x: x + 1.975, y: 2.275, w: 0.35, h: 0.35 });
         }
       });
       // terminal dot after Review box
@@ -606,7 +606,7 @@ module.exports = [
           fontSize: 14, fontFace: FONT.head, color: C.offWhite, bold: true, align: "center", valign: "middle", margin: 0
         });
         if (i < loopSteps.length - 1) {
-          s.addImage({ data: icons.arrowWhite, x: x + 1.85, y: 3.7, w: 0.2, h: 0.2 });
+          s.addImage({ data: icons.arrow, x: x + 1.975, y: 3.675, w: 0.35, h: 0.35 });
         }
       });
       // feedback arrow label from Review back to Plan
@@ -955,6 +955,7 @@ module.exports = [
     render(pres, ctx) {
       const { C, FONT, makeShadow } = ctx.branding;
       const { darkSlide, addCard } = ctx.helpers;
+      const { icons } = ctx;
 
       const s = darkSlide(pres, FT);
       s.addText("Scaling the Loop", {
@@ -1006,11 +1007,7 @@ module.exports = [
           align: "center", valign: "middle", margin: 0
         });
         if (i < 2) {
-          s.addText("\u2192", {
-            x: sx + stepW, y: 3.05, w: stepGap, h: 0.55,
-            fontSize: 18, fontFace: FONT.body, color: C.muted,
-            align: "center", valign: "middle", margin: 0
-          });
+          s.addImage({ data: icons.arrow, x: sx + stepW + (stepGap - 0.35) / 2, y: 3.15, w: 0.35, h: 0.35 });
         }
       });
 


### PR DESCRIPTION
## Summary

- **New slide: Welcome & Introductions** — inserted as slide 3 (after the roadmap, before context-setting). Uses the ACTIVITY layout with four numbered prompts: name, employer, AI tools in use, and workshop goals. Includes a 1-min-each time guide and speaker notes reminding the presenter to go first and listen for AI experience signals.
- **Intro reorder** — "Your Journey Today" and "Welcome & Introductions" moved to slides 2–3 so the audience sees the roadmap and introduces themselves before diving into content.
- **Arrow standardisation across 10 slides** — replaces unicode triangles (▶) and thin text glyphs (→) used as structural connectors with the `icons.arrow` FA icon. Sizes normalised to 0.35" throughout (0.30" on slide 56 where box spacing constrains it). All flow arrows use the accent green rather than white, so connectors sit within the palette rather than dominating the slide.

## Slides changed
| Slide | Change |
|---|---|
| 2 | Reordered to position 2; unicode ▶ → icons.arrow |
| 3 | **New** — Welcome & Introductions |
| 11 | icons.arrow resized 0.5 → 0.35" |
| 17 | unicode → → icons.arrow |
| 39 | icons.arrowWhite resized 0.5 → 0.35", switched to icons.arrow |
| 56 | icons.arrowWhite resized 0.2 → 0.30", switched to icons.arrow |
| 57 | icons.arrowWhite resized 0.2 → 0.35", switched to icons.arrow |
| 64 | unicode → → icons.arrow |
| 70 | unicode ▶ → icons.arrow, resized to 0.35" |
| 74 | unicode ▶ → icons.arrow, resized to 0.35" |

## Test plan
- [x] `node build.js` completes without errors
- [ ] PDF renders slides 2–3 correctly (roadmap then introductions)
- [x] All 10 flow arrow slides show consistent green FA arrows at uniform visual weight
- [x] No overflow or layout issues on the Welcome & Introductions slide

🤖 Generated with [Claude Code](https://claude.com/claude-code)